### PR TITLE
Add Miniplayer

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -4,6 +4,7 @@
 #include <QIcon>
 #include <QMimeData>
 #include <QFileDialog>
+#include <QPropertyAnimation>
 
 #include "m3uparser.h"
 #include "m3uwriter.h"
@@ -189,6 +190,43 @@ void MainWindow::on_qaSavePlaylist_triggered()
 
     auto playlistPath = files.first();
     savePlaylistToFile(playlistPath);
+}
+
+void MainWindow::on_qaMiniplayer_triggered(bool checked)
+{
+    static int previousHeight = 320;
+    auto animation = new QPropertyAnimation(this, "size");
+    animation->setDuration(500);
+    animation->setEasingCurve(QEasingCurve::InOutQuart);
+
+    connect(animation, &QPropertyAnimation::finished, this, [=]()
+    {
+        if (checked)
+        {
+            setMaximumHeight(height());
+        }
+        else
+        {
+            ui->tableView->show();
+        }
+    });
+
+    if (checked)
+    {
+        previousHeight = height();
+        animation->setStartValue(QSize(width(), previousHeight));
+        animation->setEndValue(QSize(width(), ui->toolBar->height()));
+    }
+    else
+    {
+        setMaximumHeight(maximumWidth()); // maximumWidth is always max
+        animation->setStartValue(QSize(width(), height()));
+        animation->setEndValue(QSize(width(), previousHeight));
+    }
+
+    ui->toolBar->setMovable(!checked);
+    ui->tableView->hide();
+    animation->start();
 }
 
 void MainWindow::onSongChange(QString songName)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -45,6 +45,7 @@ private slots:
     void on_qaPrevious_triggered();
     void on_qaLoadPlaylist_triggered();
     void on_qaSavePlaylist_triggered();
+    void on_qaMiniplayer_triggered(bool checked);
 
     void onSongChange(QString songName);
     void onRowUpdate(int row, int pattern, int channels);

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -6,9 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>573</width>
-    <height>275</height>
+    <width>600</width>
+    <height>320</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>600</width>
+    <height>0</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>🦊📦</string>
@@ -47,7 +53,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>573</width>
+     <width>600</width>
      <height>22</height>
     </rect>
    </property>
@@ -58,7 +64,14 @@
     <addaction name="qaLoadPlaylist"/>
     <addaction name="qaSavePlaylist"/>
    </widget>
+   <widget class="QMenu" name="menu_View">
+    <property name="title">
+     <string>&amp;View</string>
+    </property>
+    <addaction name="qaMiniplayer"/>
+   </widget>
    <addaction name="menu_File"/>
+   <addaction name="menu_View"/>
   </widget>
   <widget class="QToolBar" name="toolBar">
    <property name="windowTitle">
@@ -69,6 +82,9 @@
    </property>
    <property name="orientation">
     <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="floatable">
+    <bool>false</bool>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -133,6 +149,17 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+S</string>
+   </property>
+  </action>
+  <action name="qaMiniplayer">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Miniplayer</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+M</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Resolves #4.

This effectively just hides the playlist, but it does so with a really nice animation thanks to the `QPropertyAnimation` class.