### PR TITLE
QtMultimedia backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ personal player for tracked music using libopenmpt as backend
 
 ## Build requirements
 
-- libao
+- QtMultimedia
 - libopenmpt (NOT libmodplug!)
 - Qt 5.12+
 

--- a/foxbox.pro
+++ b/foxbox.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       += core gui
+QT       += core gui multimedia
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
@@ -61,7 +61,7 @@ else: unix:!android: target.path = /opt/$${TARGET}/bin
 INCLUDEPATH += \
     /usr/local/include
 LIBS += \
-    -L/usr/local/lib -lopenmpt -lao
+    -L/usr/local/lib -lopenmpt
 
 RESOURCES += \
     res.qrc

--- a/main.cpp
+++ b/main.cpp
@@ -2,16 +2,12 @@
 #include <QFontDatabase>
 #include <QStyleFactory>
 
-#include <ao/ao.h>
-
 #include "nativefilters.h"
 #include "mainwindow.h"
 #include "styledmainwindow.h"
 
 int main(int argc, char *argv[])
 {
-    ao_initialize();
-
     QApplication a(argc, argv);
     a.setApplicationName("foxbox");
     a.setApplicationVersion("0.1.0");
@@ -63,8 +59,6 @@ int main(int argc, char *argv[])
     sw.show();
 
     auto ret = a.exec();
-
-    ao_shutdown();
 
     return ret;
 }

--- a/player.h
+++ b/player.h
@@ -4,7 +4,7 @@
 #include <QObject>
 #include <QMutex>
 
-#include <ao/ao.h>
+#include <QAudioOutput>
 
 #include "playlist.h"
 
@@ -42,8 +42,7 @@ private:
     bool _playing = false;
     bool _loop = false;
 
-    int _ao_driver_id = -1;
-    ao_device* _ao_device = nullptr;
+    QAudioOutput* _audioOutput = nullptr;
 
     int _row = 0;
     int _pattern = 0;

--- a/player.h
+++ b/player.h
@@ -47,7 +47,7 @@ private:
     int _row = 0;
     int _pattern = 0;
 
-    double _volume = 1.0;
+    qreal _volume = 1.0;
 };
 
 #endif // PLAYER_H


### PR DESCRIPTION
Pros:
- we can use `float` instead of `int16_t` now
- playback of audio is much nicer now on Linux
- no external dependency anymore (apart from libopenmpt and QtMultimedia which may be packaged separately)
- volume is now handled by QAudioOutput

Cons:
- it probably uses more CPU depending on the platform
- could do some additional refactorings
- perhaps needs to be made more efficient overall

```ruby
pros.count > cons.count # => true
```

==> that's why I include it in `master` now.